### PR TITLE
fix-services-binding-initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/
@@ -59,6 +60,7 @@
 **/ios/Flutter/app.flx
 **/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
+**/ios/Flutter/Flutter.podspec
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:jobber/src/app.dart';
 import 'package:jobber/src/core/models/settings.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await appSettings.getPrefsInstance();
   runApp(JobberApp());
 }


### PR DESCRIPTION
ran into this error message when I run: 

```

Xcode build done.                                           12.4s
[VERBOSE-2:ui_dart_state.cc(157)] Unhandled Exception: ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.
If you're running an application and need to access the binary messenger before `runApp()` has been called (for example, during plugin initialization), then you need to explicitly call the `WidgetsFlutterBinding.ensureInitialized()` first.
If you're running a test, you can call the `TestWidgetsFlutterBinding.ensureInitialized()` as the first line in your test's `main()` method to initialize the binding.
#0      defaultBinaryMessenger.<anonymous closure> (package:flutter/src/services/binary_messenger.dart:76:7)
#1      defaultBinaryMessenger (package:flutter/src/services/binary_messenger.dart:89:4)
#2      MethodChannel.binaryMessenger (package:flutter/src/services/platform_channel.dart:140:62)
#3      MethodChannel.invokeMethod (package:flutter/src/services/platform_channel.dart:314:35)
#4      SharedPreferences._getSharedPreferencesMap (package:shared_prefere<…>
Syncing files to device iPhone 11 Pro Max...

```
with flutter version: 
```
flutter doctor -v
[✓] Flutter (Channel stable, v1.12.13+hotfix.5, on Mac OS X 10.15.2 19C57, locale en-US)
    • Flutter version 1.12.13+hotfix.5 at /Users/dv/flutter
    • Framework revision 27321ebbad (4 weeks ago), 2019-12-10 18:15:01 -0800
    • Engine revision 2994f7e1e6
    • Dart version 2.7.0
```

following the suggestion seems to fix the issue: call `WidgetsFlutterBinding.ensureInitialized()` prior to calling `SharedPreferences.getInstance()`

Also added a few files in the `.gitignore`

`ios/Flutter/flutter_export_environment.sh` changes on my end i.e `export "FLUTTER_ROOT=/Users/sanderlarsen/flutter"` becomes `export "FLUTTER_ROOT=/Users/dv/flutter"` 

`ios/Podfile.lock` changes from
COCOAPODS: 1.7.5
COCOAPODS: 1.8.4

not checking these in



